### PR TITLE
vim-buftabline support: make current and active buffers stand out

### DIFF
--- a/colors/bogster.vim
+++ b/colors/bogster.vim
@@ -62,7 +62,7 @@ if has('nvim')
     let g:terminal_color_13 = g:bogster_colors["pink"][0]
 
     let g:terminal_color_6 = g:bogster_colors["teal"][0]
-    let g:terminal_color_14 = g:bogster_colors["lteal"][0] 
+    let g:terminal_color_14 = g:bogster_colors["lteal"][0]
 
     let g:terminal_color_7 = g:bogster_colors["fg0"][0]
     let g:terminal_color_15 = g:bogster_colors["fg1"][0]
@@ -116,13 +116,13 @@ function! s:__hl(group, guifg, ...)
     else
         let style = "NONE"
     endif
-    
+
     let hi_str = [ "hi", a:group,
             \ 'guifg=' . fg[0], "ctermfg=" . fg[1],
             \ 'guibg=' . bg[0], "ctermbg=" . bg[1],
             \ 'gui=' . style, "cterm=" . style
             \ ]
-    
+
     execute join(hi_str, ' ')
 endfunction
 
@@ -266,6 +266,11 @@ hi! link asmDirective Function
 hi! link bibEntryKw LibraryIdent
 hi! link bibKey IdentifierDef
 hi! link bibType LibraryType
+
+" buftabline
+hi! link BufTabLineCurrent Pmenu
+hi! link BufTabLineActive PmenuSel
+
 
 " C
 


### PR DESCRIPTION
## What?

[vim-buftabline](https://github.com/ap/vim-buftabline] is a plugin that shows the list of buffers at the top of the window. It provides 4 highlight groups: 

| Name | Maps to | bogster colors | Intent |
|-------|----------|---------|----------|
| BufTabLineCurrent | Pmenu | "base1", "base3" | Buffer currently being edited |
| BufTabLineActive | PmenuSel | "fg0", "base2" | Visible buffer (split) but not being edited |
| BufTabLineHidden | TabLine | "base1", "base3" | Opened buffer, but not visible |
| BufTabLineFill | TabLineFill | "base1", "base3" | Background color of the tabline |

➡️ **the current edited buffer has the same colors as the inactive ones and the buffer line background**, which is very misleading.

Screen 1:
<img width="1552" alt="Capture d’écran 2021-05-16 à 19 53 58" src="https://user-images.githubusercontent.com/769918/118409425-a383d480-b68a-11eb-877e-bfbf76061085.png">

Screen 2 (even worse, with a split, the buffer currently edited is not emphasized, and the visible buffer that I'm not editing is, very misleading)
<img width="1552" alt="Capture d’écran 2021-05-16 à 19 53 54" src="https://user-images.githubusercontent.com/769918/118409533-2ad14800-b68b-11eb-9603-2d36f83cfd73.png">

## This PR

I tweaked the `BufTabLineCurrent` and  `BufTabLineActive` to make the active buffers more visible. I let the other two groups [as defined by vim-buftabline](https://github.com/ap/vim-buftabline/blob/master/plugin/buftabline.vim#L32-L35) to keep this config as close from the original intent of the addon as possible (I suppose the less it differs, the easiest it is to maintain)

Sceen 1:
<img width="1552" alt="Capture d’écran 2021-05-16 à 19 58 38" src="https://user-images.githubusercontent.com/769918/118409465-e5ad1600-b68a-11eb-8e61-70e911a89043.png">

